### PR TITLE
feat: 単発予定変更時にslackに投稿されるメッセージを繰り返し予定と同じ形式に変更 (#CIT-764)

### DIFF
--- a/src/ModificationAndDeletionSheet.ts
+++ b/src/ModificationAndDeletionSheet.ts
@@ -19,7 +19,6 @@ type ModificationRow = z.infer<typeof ModificationRow>;
 const DeletionRow = z.object({
   type: z.literal("deletion"),
   title: z.string(),
-  date: DateAfterNow, //TODO: 日付情報だけの変数dateを消去する
   startTime: DateAfterNow,
   endTime: DateAfterNow,
 });
@@ -184,7 +183,6 @@ const getModificationOrDeletionRows = (
         return DeletionRow.parse({
           type: "deletion",
           title: row.title,
-          date: startTime,
           startTime: startTime,
           endTime: endTime,
         });

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -183,6 +183,10 @@ export const callModificationAndDeletion = () => {
   const sheet = getSheet("modificationAndDeletion", spreadsheetUrl);
 
   const { comment, modificationRows, deletionRows } = getModificationOrDeletionSheetValues(sheet);
+  if (modificationRows.length === 0 && deletionRows.length === 0) {
+    throw new Error("変更・削除する予定がありません。");
+  }
+
   console.info(`modification: ${JSON.stringify(modificationRows)},deletion: ${JSON.stringify(deletionRows)}`); //NOTE: シート内容を確認するためのログ
   const modificationInfos = modificationRows.map(
     ({ title, startTime, endTime, newStartTime, newEndTime, newRestStartTime, newRestEndTime, newWorkingStyle }) => {

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -116,12 +116,12 @@ export const callRegistration = () => {
   const { API_URL, SLACK_CHANNEL_TO_POST } = getConfig();
   UrlFetchApp.fetch(API_URL, options);
   const { job, lastName } = partTimerProfile;
-  const messageToNotify = `
-  ${job}${lastName}さんが以下の単発シフトを追加しました
-  ${createRegistrationMessage(registrationInfos)}
-  ---
-  コメント: ${comment}
-`.trim();
+  const messageToNotify = [
+    `${job}${lastName}さんが以下の単発シフトを追加しました`,
+    createRegistrationMessage(registrationInfos),
+    "---",
+    `コメント: ${comment}`,
+  ].join("\n");
   postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, messageToNotify, partTimerProfile);
   sheet.clear();
   SpreadsheetApp.flush();
@@ -244,13 +244,15 @@ export const callModificationAndDeletion = () => {
 
   const { SLACK_CHANNEL_TO_POST } = getConfig();
   const { job, lastName } = partTimerProfile;
-  const modificationAndDeletionMessageToNotify = `
-  ${job}${lastName}さんが以下の単発シフトを変更しました
-  ${createModificationMessage(modificationInfos)}
-  ${createDeletionMessage(deletionInfos)}
-  ---
-  コメント: ${comment}
-`.trim();
+  const modificationAndDeletionMessageToNotify = [
+    `${job}${lastName}さんが以下の単発シフトを変更しました`,
+    createModificationMessage(modificationInfos),
+    createDeletionMessage(deletionInfos),
+    "---",
+    `コメント: ${comment}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
 
   postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, modificationAndDeletionMessageToNotify, partTimerProfile);
   sheet.clear();
@@ -264,8 +266,8 @@ const createRegistrationMessage = (eventInfos: Event[]): string => {
   return `${messageTitle}\n${messages.join("\n")}`;
 };
 
-const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent: Event }[]): string => {
-  if (eventInfos.length === 0) return "";
+const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent: Event }[]): string | undefined => {
+  if (eventInfos.length === 0) return;
   const messages = eventInfos.map(({ previousEvent, newEvent }) => {
     return `${createMessageFromEventInfo(previousEvent)} → ${createMessageFromEventInfo(newEvent)}`;
   });
@@ -273,8 +275,8 @@ const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent:
   return `${messageTitle}\n${messages.join("\n")}`;
 };
 
-const createDeletionMessage = (eventInfos: Event[]): string => {
-  if (eventInfos.length === 0) return "";
+const createDeletionMessage = (eventInfos: Event[]): string | undefined => {
+  if (eventInfos.length === 0) return;
   const messages = eventInfos.map(createMessageFromEventInfo);
   const messageTitle = "[消去]";
   return `${messageTitle}\n${messages.join("\n")}`;

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -116,12 +116,12 @@ export const callRegistration = () => {
   const { API_URL, SLACK_CHANNEL_TO_POST } = getConfig();
   UrlFetchApp.fetch(API_URL, options);
   const { job, lastName } = partTimerProfile;
-  const messageToNotify = [
-    `${job}${lastName}さんが以下の単発シフトを追加しました`,
-    createRegistrationMessage(registrationInfos),
-    "---",
-    `コメント: ${comment}`,
-  ].join("\n");
+  const messageToNotify = `
+  ${job}${lastName}さんが以下の単発シフトを追加しました
+  ${createRegistrationMessage(registrationInfos)}
+  ---
+  コメント: ${comment}
+`.trim();
   postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, messageToNotify, partTimerProfile);
   sheet.clear();
   SpreadsheetApp.flush();
@@ -244,15 +244,13 @@ export const callModificationAndDeletion = () => {
 
   const { SLACK_CHANNEL_TO_POST } = getConfig();
   const { job, lastName } = partTimerProfile;
-  const modificationAndDeletionMessageToNotify = [
-    `${job}${lastName}さんが以下の単発シフトを変更しました`,
-    createModificationMessage(modificationInfos),
-    createDeletionMessage(deletionInfos),
-    "---",
-    `コメント: ${comment}`,
-  ]
-    .filter(Boolean)
-    .join("\n");
+  const modificationAndDeletionMessageToNotify = `
+  ${job}${lastName}さんが以下の単発シフトを変更しました
+  ${createModificationMessage(modificationInfos)}
+  ${createDeletionMessage(deletionInfos)}
+  ---
+  コメント: ${comment}
+`.trim();
 
   postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, modificationAndDeletionMessageToNotify, partTimerProfile);
   sheet.clear();
@@ -473,14 +471,14 @@ const createMessageForRecurringEvent = (
   deleteEventStrings: string,
   comment: string,
 ): string => {
-  const message = [
-    `${job}${lastName}さんが${format(after, "yyyy/MM/dd")}以降の固定シフトを変更しました`,
+  const recurringMessageToNotify = `
+    ${job}${lastName}さんが${format(after, "yyyy/MM/dd")}以降の固定シフトを変更しました
     registerEventStrings,
     modifyEventStrings,
     deleteEventStrings,
-  ].join("\n");
+  `.trim();
 
-  return `${message}\n---\nコメント: ${comment}`;
+  return `${recurringMessageToNotify}\n---\nコメント: ${comment}`;
 };
 
 const getSlackClient = (slackToken: string): SlackClient => {

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -263,7 +263,8 @@ export const callModificationAndDeletion = () => {
 const createRegistrationMessage = (eventInfos: Event[]): string => {
   const messages = eventInfos.map(createMessageFromEventInfo);
   const messageTitle = "[追加]";
-  return `• ${messageTitle}\n${messages.join("\n")}`;
+  const formattedMessages = messages.map((message) => `• ${message}`).join("\n");
+  return `${messageTitle}\n${formattedMessages}`;
 };
 
 const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent: Event }[]): string | undefined => {
@@ -279,7 +280,8 @@ const createDeletionMessage = (eventInfos: Event[]): string | undefined => {
   if (eventInfos.length === 0) return;
   const messages = eventInfos.map(createMessageFromEventInfo);
   const messageTitle = "[消去]";
-  return `• ${messageTitle}\n${messages.join("\n")}`;
+  const formattedMessages = messages.map((message) => `• ${message}`).join("\n");
+  return `${messageTitle}\n${formattedMessages}`;
 };
 
 export const callRecurringEvent = () => {

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -264,8 +264,8 @@ const createRegistrationMessage = (eventInfos: Event[]): string => {
   return `${messageTitle}\n${messages.join("\n")}`;
 };
 
-const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent: Event }[]): string | undefined => {
-  if (eventInfos.length === 0) return;
+const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent: Event }[]): string => {
+  if (eventInfos.length === 0) return "";
   const messages = eventInfos.map(({ previousEvent, newEvent }) => {
     return `${createMessageFromEventInfo(previousEvent)} → ${createMessageFromEventInfo(newEvent)}`;
   });
@@ -273,8 +273,8 @@ const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent:
   return `${messageTitle}\n${messages.join("\n")}`;
 };
 
-const createDeletionMessage = (eventInfos: Event[]): string | undefined => {
-  if (eventInfos.length === 0) return;
+const createDeletionMessage = (eventInfos: Event[]): string => {
+  if (eventInfos.length === 0) return "";
   const messages = eventInfos.map(createMessageFromEventInfo);
   const messageTitle = "[消去]";
   return `${messageTitle}\n${messages.join("\n")}`;
@@ -473,9 +473,9 @@ const createMessageForRecurringEvent = (
 ): string => {
   const recurringMessageToNotify = `
     ${job}${lastName}さんが${format(after, "yyyy/MM/dd")}以降の固定シフトを変更しました
-    registerEventStrings,
-    modifyEventStrings,
-    deleteEventStrings,
+    ${registerEventStrings}
+    ${modifyEventStrings}
+    ${deleteEventStrings}
   `.trim();
 
   return `${recurringMessageToNotify}\n---\nコメント: ${comment}`;

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -253,7 +253,7 @@ export const callModificationAndDeletion = () => {
     "---",
     `コメント: ${comment}`,
   ]
-    .filter((message) => message !== "")
+    .filter(Boolean)
     .join("\n");
 
   postMessageToSlackChannel(client, SLACK_CHANNEL_TO_POST, modificationAndDeletionMessageToNotify, partTimerProfile);
@@ -262,8 +262,8 @@ export const callModificationAndDeletion = () => {
   setValuesModificationAndDeletionSheet(sheet);
 };
 
-const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent: Event }[]) => {
-  if (eventInfos.length === 0) return "";
+const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent: Event }[]): string | undefined => {
+  if (eventInfos.length === 0) return;
   const messages = eventInfos.map(({ previousEvent, newEvent }) => {
     return `${createMessageFromEventInfo(previousEvent)} → ${createMessageFromEventInfo(newEvent)}`;
   });
@@ -271,8 +271,8 @@ const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent:
   return `${messageTitle}\n${messages.join("\n")}`;
 };
 
-const createDeletionMessage = (eventInfos: Event[]) => {
-  if (eventInfos.length === 0) return "";
+const createDeletionMessage = (eventInfos: Event[]): string | undefined => {
+  if (eventInfos.length === 0) return;
   const messages = eventInfos.map(createMessageFromEventInfo);
   const messageTitle = "[消去]";
   return `${messageTitle}\n${messages.join("\n")}`;

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -137,7 +137,7 @@ export const callRegistration = () => {
   UrlFetchApp.fetch(API_URL, options);
   const { job, lastName } = partTimerProfile;
   const messageToNotify = [
-    `${job}${lastName}さんが以下の単発シフトを変更しました`,
+    `${job}${lastName}さんが以下の単発シフトを追加しました`,
     createMessage({ type: "registerEvent", eventInfos: registrationInfos }),
     "---",
     `コメント: ${comment}`,

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -187,10 +187,9 @@ export const callModificationAndDeletion = () => {
         partTimerProfile,
       );
       return {
-        previousEvent: { title, date: startTime, startTime, endTime },
+        previousEvent: { title, startTime, endTime },
         newEvent: {
           title: newTitle,
-          date: newStartTime,
           startTime: newStartTime,
           endTime: newEndTime,
         },
@@ -244,22 +243,9 @@ export const callModificationAndDeletion = () => {
 
 const createMessage = (
   partTimerProfile: PartTimerProfile,
-  registrationInfos?: Event[],
-  modificationInfos?: {
-    previousEvent: {
-      title: string;
-      date: Date;
-      startTime: Date;
-      endTime: Date;
-    };
-    newEvent: {
-      title: string;
-      date: Date;
-      startTime: Date;
-      endTime: Date;
-    };
-  }[],
-  deletionInfos?: Event[],
+  registrationInfos?: RegisterEventRequest["events"],
+  modificationInfos?: ModifyEventRequest["events"],
+  deletionInfos?: DeleteEventRequest["events"],
 ): string => {
   const { job, lastName } = partTimerProfile;
   const message: string[] = [`${job}${lastName}さんが以下の単発シフトを変更しました`];

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -474,7 +474,7 @@ const createMessageForRecurringEvent = (
   comment: string,
 ): string => {
   const message = [
-    `🔄${job}${lastName}さんが${format(after, "yyyy/MM/dd")}以降の固定シフトを変更しました🔄`,
+    `${job}${lastName}さんが${format(after, "yyyy/MM/dd")}以降の固定シフトを変更しました`,
     registerEventStrings,
     modifyEventStrings,
     deleteEventStrings,

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -262,7 +262,7 @@ export const callModificationAndDeletion = () => {
 
 const createRegistrationMessage = (eventInfos: Event[]): string => {
   const messages = eventInfos.map(createMessageFromEventInfo);
-  const messageTitle = "[ 追加 ]"; //TODO: 後で修正
+  const messageTitle = "[追加]";
   return `• ${messageTitle}\n${messages.join("\n")}`;
 };
 

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -262,7 +262,7 @@ export const callModificationAndDeletion = () => {
 
 const createRegistrationMessage = (eventInfos: Event[]): string => {
   const messages = eventInfos.map(createMessageFromEventInfo);
-  const messageTitle = "[追加]";
+  const messageTitle = "[ 追加 ]"; //TODO: 後で修正
   return `• ${messageTitle}\n${messages.join("\n")}`;
 };
 

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -128,12 +128,6 @@ export const callRegistration = () => {
   setValuesRegistrationSheet(sheet);
 };
 
-const createRegistrationMessage = (eventInfos: Event[]) => {
-  const messages = eventInfos.map(createMessageFromEventInfo);
-  const messageTitle = "[追加]";
-  return `${messageTitle}\n${messages.join("\n")}`;
-};
-
 export const callShowEvents = () => {
   const userEmail = Session.getActiveUser().getEmail();
   const spreadsheetUrl = SpreadsheetApp.getActiveSpreadsheet().getUrl();
@@ -260,6 +254,12 @@ export const callModificationAndDeletion = () => {
   sheet.clear();
   SpreadsheetApp.flush();
   setValuesModificationAndDeletionSheet(sheet);
+};
+
+const createRegistrationMessage = (eventInfos: Event[]): string => {
+  const messages = eventInfos.map(createMessageFromEventInfo);
+  const messageTitle = "[追加]";
+  return `${messageTitle}\n${messages.join("\n")}`;
 };
 
 const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent: Event }[]): string | undefined => {

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -263,13 +263,13 @@ export const callModificationAndDeletion = () => {
 const createRegistrationMessage = (eventInfos: Event[]): string => {
   const messages = eventInfos.map(createMessageFromEventInfo);
   const messageTitle = "[追加]";
-  return `${messageTitle}\n${messages.join("\n")}`;
+  return `• ${messageTitle}\n${messages.join("\n")}`;
 };
 
 const createModificationMessage = (eventInfos: { previousEvent: Event; newEvent: Event }[]): string | undefined => {
   if (eventInfos.length === 0) return;
   const messages = eventInfos.map(({ previousEvent, newEvent }) => {
-    return `${createMessageFromEventInfo(previousEvent)} → ${createMessageFromEventInfo(newEvent)}`;
+    return `• ${createMessageFromEventInfo(previousEvent)} → ${createMessageFromEventInfo(newEvent)}`;
   });
   const messageTitle = "[変更]";
   return `${messageTitle}\n${messages.join("\n")}`;
@@ -279,7 +279,7 @@ const createDeletionMessage = (eventInfos: Event[]): string | undefined => {
   if (eventInfos.length === 0) return;
   const messages = eventInfos.map(createMessageFromEventInfo);
   const messageTitle = "[消去]";
-  return `${messageTitle}\n${messages.join("\n")}`;
+  return `• ${messageTitle}\n${messages.join("\n")}`;
 };
 
 export const callRecurringEvent = () => {
@@ -529,8 +529,8 @@ const createMessageFromEventInfo = (eventInfo: Event) => {
   const startTime = format(eventInfo.startTime, "HH:mm");
   const endTime = format(eventInfo.endTime, "HH:mm");
   if (restStartTime === undefined || restEndTime === undefined)
-    return `• ${date}: ${emojiWorkingStyle} ${startTime}~${endTime}`;
-  else return `• ${date}: ${emojiWorkingStyle} ${startTime}~${endTime} (休憩: ${restStartTime}~${restEndTime})`;
+    return `${date}: ${emojiWorkingStyle} ${startTime}~${endTime}`;
+  else return `${date}: ${emojiWorkingStyle} ${startTime}~${endTime} (休憩: ${restStartTime}~${restEndTime})`;
 };
 const getEventInfoFromTitle = (
   title: string,

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -490,7 +490,7 @@ const createMessageForRecurringEvent = (
   comment: string,
 ): string => {
   const message = [
-    `${job}${lastName}さんが${format(after, "yyyy/MM/dd")}以降の固定シフトを変更しました`,
+    `🔄${job}${lastName}さんが${format(after, "yyyy/MM/dd")}以降の固定シフトを変更しました🔄`,
     registerEventStrings,
     modifyEventStrings,
     deleteEventStrings,

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -205,7 +205,7 @@ export const callModificationAndDeletion = () => {
     },
   );
 
-  const deleteInfos = deletionRows.map(({ title, startTime, endTime }) => {
+  const deletionInfos = deletionRows.map(({ title, startTime, endTime }) => {
     return { title, startTime, endTime };
   });
 
@@ -224,11 +224,11 @@ export const callModificationAndDeletion = () => {
     };
     UrlFetchApp.fetch(API_URL, options);
   }
-  if (deleteInfos.length > 0) {
+  if (deletionInfos.length > 0) {
     const payload = JSON.stringify({
       ...basePayload,
       operationType: "deleteEvent",
-      events: deleteInfos,
+      events: deletionInfos,
     } satisfies DeleteEventRequest);
     const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
       method: "post",
@@ -243,7 +243,7 @@ export const callModificationAndDeletion = () => {
   const modificationAndDeletionMessageToNotify = [
     `${job}${lastName}さんが以下の単発シフトを変更しました`,
     createModificationMessage(modificationInfos),
-    createDeletionMessage(deleteInfos),
+    createDeletionMessage(deletionInfos),
     "---",
     `コメント: ${comment}`,
   ]

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -1,6 +1,5 @@
 import { GasWebClient as SlackClient } from "@hi-se/web-api";
 import { format } from "date-fns";
-import { z } from "zod";
 
 import { deleteHolidayShift } from "./autoDeleteHolidayEvent";
 import { DayOfWeek } from "./common.schema";
@@ -30,26 +29,25 @@ import {
   ShowEventRequest,
 } from "./shift-changer-api";
 
-const CreateMessageSchema = z.union([
-  z.object({
-    type: z.literal("registerEvent"),
-    eventInfos: z.array(Event),
-  }),
-  z.object({
-    type: z.literal("modifyEvent"),
-    eventInfos: z
-      .object({
-        previousEvent: Event,
-        newEvent: Event,
-      })
-      .array(),
-  }),
-  z.object({
-    type: z.literal("deleteEvent"),
-    eventInfos: z.array(Event),
-  }),
-]);
-type CreateMessageSchema = z.infer<typeof CreateMessageSchema>;
+type RegisterEventMessage = {
+  type: "registerEvent";
+  eventInfos: Event[];
+};
+
+type ModifyEventMessage = {
+  type: "modifyEvent";
+  eventInfos: {
+    previousEvent: Event;
+    newEvent: Event;
+  }[];
+};
+
+type DeleteEventMessage = {
+  type: "deleteEvent";
+  eventInfos: Event[];
+};
+
+type CreateMessageSchema = RegisterEventMessage | ModifyEventMessage | DeleteEventMessage;
 
 type SheetType = "registration" | "modificationAndDeletion" | "recurringEvent";
 

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -139,7 +139,7 @@ export const callRegistration = () => {
   UrlFetchApp.fetch(API_URL, options);
   const { job, lastName } = partTimerProfile;
   const messageToNotify = [
-    `${job}${lastName}さんが以下の単発シフトを追加しました`,
+    `${job}${lastName}さんが以下の単発シフトを変更しました`,
     createMessage({ type: "registerEvent", eventInfos: registrationInfos }),
     "---",
     `コメント: ${comment}`,
@@ -227,6 +227,10 @@ export const callModificationAndDeletion = () => {
     },
   );
 
+  const deleteInfos = deletionRows.map(({ title, startTime, endTime }) => {
+    return { title, startTime, endTime };
+  });
+
   const { API_URL } = getConfig();
   const basePayload = { apiId: "shift-changer", userEmail: userEmail } as const;
   if (modificationInfos.length > 0) {
@@ -242,10 +246,7 @@ export const callModificationAndDeletion = () => {
     };
     UrlFetchApp.fetch(API_URL, options);
   }
-  if (deletionRows.length > 0) {
-    const deleteInfos = deletionRows.map(({ title, startTime, endTime }) => {
-      return { title, startTime, endTime };
-    });
+  if (deleteInfos.length > 0) {
     const payload = JSON.stringify({
       ...basePayload,
       operationType: "deleteEvent",
@@ -264,14 +265,7 @@ export const callModificationAndDeletion = () => {
   const modificationAndDeletionMessageToNotify = [
     `${job}${lastName}さんが以下の単発シフトを変更しました`,
     createMessage({ type: "modifyEvent", eventInfos: modificationInfos }),
-    createMessage({
-      type: "deleteEvent",
-      eventInfos: deletionRows.map(({ title, startTime, endTime }) => ({
-        title,
-        startTime,
-        endTime,
-      })),
-    }),
+    createMessage({ type: "deleteEvent", eventInfos: deleteInfos }),
     "---",
     `コメント: ${comment}`,
   ].join("\n");

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -117,7 +117,7 @@ export const callRegistration = () => {
   UrlFetchApp.fetch(API_URL, options);
   const { job, lastName } = partTimerProfile;
   const messageToNotify = [
-    `${job}${lastName}さんが以下の単発シフトを追加しました`,
+    `${job}${lastName}さんが以下の単発シフトを変更しました`,
     createRegistrationMessage(registrationInfos),
     "---",
     `コメント: ${comment}`,

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -471,14 +471,14 @@ const createMessageForRecurringEvent = (
   deleteEventStrings: string,
   comment: string,
 ): string => {
-  const recurringMessageToNotify = `
-    ${job}${lastName}さんが${format(after, "yyyy/MM/dd")}以降の固定シフトを変更しました
-    ${registerEventStrings}
-    ${modifyEventStrings}
-    ${deleteEventStrings}
-  `.trim();
+  const message = [
+    `${job}${lastName}さんが${format(after, "yyyy/MM/dd")}以降の固定シフトを変更しました`,
+    registerEventStrings,
+    modifyEventStrings,
+    deleteEventStrings,
+  ].join("\n");
 
-  return `${recurringMessageToNotify}\n---\nコメント: ${comment}`;
+  return `${message}\n---\nコメント: ${comment}`;
 };
 
 const getSlackClient = (slackToken: string): SlackClient => {


### PR DESCRIPTION
slackに投稿されるメッセージが繰り返し予定と単発予定でフォーマットが違ったので統一した。
そして、コメントを作成する関数をリファクタリンした。

変更前
```
Tech和田さんの以下の単発シフトが変更されました。
07/12: :shussha: 14:00~17:00 → 07/19: :remote: 13:00~15:00
---
コメント:test
```
変更後
```
Tech和田さんが以下の単発シフトを変更しました
[変更]
• 08/30: :shussha: 11:00~13:00 → 08/31: :remote: 14:00~15:00
---
コメント: test
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **新機能**
  - 削除イベントのデータ構造を簡素化し、`date`フィールドを削除しました。
  - 新しいメッセージ作成スキーマを導入し、メッセージ作成プロセスを統一しました。

- **改善**
  - メッセージ作成関数を統一して冗長性を排除し、メンテナンス性を向上させました。
  - メッセージ形式を簡潔にし、可読性を向上させました。
  - 空のメッセージを除外するロジックを強化しました。
  - 削除イベントの処理を改善し、エラー処理を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->