### PR TITLE
chore: GHAの設定ファイルで`pnpm/action-setup@v4`を追加 「開発環境の最新化」 (# CIT-904)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,10 @@ jobs:
       clasp_config_project: ${{ github.workspace }}/.clasp.prod.json
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
       - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v3
         with:
           node-version: 20
           cache: "pnpm"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+      - uses: pnpm/action-setup@v4
         with:
           node-version: 20
           cache: "pnpm"


### PR DESCRIPTION
#61 でyarnからpnpmに移行した。その際にGHAも変更したが、`pnpm/action-setup@v4`を入れるのを忘れていたので追加した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- デプロイメントのワークフローに `pnpm` パッケージマネージャーを導入し、依存関係管理とキャッシュ効率を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->