### PR TITLE
chore: type-checkとlintを実行するGHAの導入 (# CIT-931)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,8 +1,10 @@
 name: Check
 on:
-  workflow_dispatch:
   pull_request:
-  workflow_call:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,10 +2,7 @@ name: Check
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches:
-      - main
-
+  workflow_call:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Type check
-        run: pnpm run type-check
+        run: pnpm type-check
   lint:
     name: lint
     runs-on: ubuntu-latest
@@ -41,4 +41,4 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Lint
-        run: pnpm run lint
+        run: pnpm lint

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,11 +1,10 @@
 name: Check
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     branches:
-      - "main"
-    paths-ignore:
-      - "**.md"
-  workflow_dispatch:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   type-check:
     name: type-check
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -25,6 +26,7 @@ jobs:
 
   lint:
     name: lint
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,39 @@
+name: Check
+on:
+  push:
+    branches:
+      - "main"
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch:
+
+jobs:
+  type-check:
+    name: type-check
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+      - name: Type check
+        run: pnpm run type-check
+
+  lint:
+    name: lint
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint
+        run: pnpm run lint

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,10 @@ on:
       - "**.md"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   type-check:
     name: type-check
@@ -23,7 +27,6 @@ jobs:
         run: pnpm install
       - name: Type check
         run: pnpm run type-check
-
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,14 +6,12 @@ on:
       - "main"
     paths-ignore:
       - "**.md"
-  workflow_call:
-    inputs:
-      workflow_id: "Check"
-      branch: "main"
-      workflow_dispatch:
   workflow_dispatch:
 jobs:
+  check:
+    users: ./.github/workflows/check.yml
   deploy:
+    needs: [check]
     runs-on: ubuntu-latest
     env:
       clasp_config_project: ${{ github.workspace }}/.clasp.prod.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   check:
-    users: ./.github/workflows/check.yml
+    uses: ./.github/workflows/check.yml
   deploy:
     needs: [check]
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,12 @@ on:
       - "main"
     paths-ignore:
       - "**.md"
+  workflow_call:
+    inputs:
+      workflow_id: "Check"
+      branch: "main"
+      workflow_dispatch:
   workflow_dispatch:
-
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,9 @@ jobs:
     env:
       clasp_config_project: ${{ github.workspace }}/.clasp.prod.json
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,10 +8,7 @@ on:
       - "**.md"
   workflow_dispatch:
 jobs:
-  check:
-    uses: ./.github/workflows/check.yml
   deploy:
-    needs: [check]
     runs-on: ubuntu-latest
     env:
       clasp_config_project: ${{ github.workspace }}/.clasp.prod.json


### PR DESCRIPTION
#63 でtype-checkとlint用のnpm scriptを追加を行った。そのスクリプトを用いてGHAで型チェックを行うようにした。
ついでに、 checkoutとsetup-nodeのバージョンがv3だったのでv4に更新を行った。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- GitHub Actionsを使用した継続的インテグレーション（CI）プロセスを導入し、コードの型チェックとリンティングを自動化。

- **改善**
	- デプロイメントワークフローにおいて、いくつかのアクションのバージョンを更新し、信頼性と効率を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->