### PR TITLE
chore: tsconfigの最新化を行う (#CIT-930)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.29.0",
     "prettier": "3.2.4",
-    "typescript": "^5.3.3"
+    "typescript": "^5.5.4"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,10 +35,10 @@ importers:
         version: 1.0.78
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.19.0
-        version: 6.19.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3)
+        version: 6.19.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0)(typescript@5.5.4)
       '@typescript-eslint/parser':
         specifier: ^6.19.0
-        version: 6.19.0(eslint@8.56.0)(typescript@5.3.3)
+        version: 6.19.0(eslint@8.56.0)(typescript@5.5.4)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -56,13 +56,13 @@ importers:
         version: 9.1.0(eslint@8.56.0)
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)
+        version: 2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0)
       prettier:
         specifier: 3.2.4
         version: 3.2.4
       typescript:
-        specifier: ^5.3.3
-        version: 5.3.3
+        specifier: ^5.5.4
+        version: 5.5.4
 
 packages:
 
@@ -2171,8 +2171,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2569,13 +2569,13 @@ snapshots:
 
   '@types/semver@7.5.6': {}
 
-  '@typescript-eslint/eslint-plugin@6.19.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3)':
+  '@typescript-eslint/eslint-plugin@6.19.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 6.19.0
-      '@typescript-eslint/type-utils': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/type-utils': 6.19.0(eslint@8.56.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 6.19.0
       debug: 4.3.4
       eslint: 8.56.0
@@ -2583,22 +2583,22 @@ snapshots:
       ignore: 5.3.0
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.3)
+      ts-api-utils: 1.0.3(typescript@5.5.4)
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.3.3)':
+  '@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.0
       '@typescript-eslint/types': 6.19.0
-      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 6.19.0
       debug: 4.3.4
       eslint: 8.56.0
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -2607,21 +2607,21 @@ snapshots:
       '@typescript-eslint/types': 6.19.0
       '@typescript-eslint/visitor-keys': 6.19.0
 
-  '@typescript-eslint/type-utils@6.19.0(eslint@8.56.0)(typescript@5.3.3)':
+  '@typescript-eslint/type-utils@6.19.0(eslint@8.56.0)(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.3.3)
-      '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.5.4)
+      '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.5.4)
       debug: 4.3.4
       eslint: 8.56.0
-      ts-api-utils: 1.0.3(typescript@5.3.3)
+      ts-api-utils: 1.0.3(typescript@5.5.4)
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@6.19.0': {}
 
-  '@typescript-eslint/typescript-estree@6.19.0(typescript@5.3.3)':
+  '@typescript-eslint/typescript-estree@6.19.0(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/types': 6.19.0
       '@typescript-eslint/visitor-keys': 6.19.0
@@ -2630,20 +2630,20 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.3)
+      ts-api-utils: 1.0.3(typescript@5.5.4)
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.19.0(eslint@8.56.0)(typescript@5.3.3)':
+  '@typescript-eslint/utils@6.19.0(eslint@8.56.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.19.0
       '@typescript-eslint/types': 6.19.0
-      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.5.4)
       eslint: 8.56.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -3167,17 +3167,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@8.56.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.5.4)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.5.4))(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -3187,7 +3187,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.19.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -3198,7 +3198,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.19.0(eslint@8.56.0)(typescript@5.5.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -4424,9 +4424,9 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-api-utils@1.0.3(typescript@5.3.3):
+  ts-api-utils@1.0.3(typescript@5.5.4):
     dependencies:
-      typescript: 5.3.3
+      typescript: 5.5.4
 
   ts2gas@4.2.0:
     dependencies:
@@ -4491,7 +4491,7 @@ snapshots:
 
   typescript@4.9.5: {}
 
-  typescript@5.3.3: {}
+  typescript@5.5.4: {}
 
   unbox-primitive@1.0.2:
     dependencies:

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -166,7 +166,9 @@ export const callShowEvents = () => {
   if (sheet.getLastRow() > 8) {
     sheet.getRange(9, 1, sheet.getLastRow() - 8, sheet.getLastColumn()).clearContent();
   }
-
+  if (!eventInfos[0]) {
+    throw new Error("no events");
+  }
   sheet.getRange(9, 1, eventInfos.length, eventInfos[0].length).setValues(eventInfos);
 };
 
@@ -448,6 +450,7 @@ const createMessageForModifyRecurringEvent = (
     }
   });
   const messages = beforeMessages.map((message, index) => {
+    if (!afterModificationInfos[index]?.dayOfWeek) return;
     return `• ${afterModificationInfos[index].dayOfWeek}: ${message} → ${afterMessages[index]}`;
   });
   return `[変更]\n${messages.join("\n")}`;

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -450,8 +450,7 @@ const createMessageForModifyRecurringEvent = (
     }
   });
   const messages = beforeMessages.map((message, index) => {
-    if (!afterModificationInfos[index]?.dayOfWeek) return;
-    return `• ${afterModificationInfos[index].dayOfWeek}: ${message} → ${afterMessages[index]}`;
+    return `• ${afterModificationInfos[index]?.dayOfWeek}: ${message} → ${afterMessages[index]}`;
   });
   return `[変更]\n${messages.join("\n")}`;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "es2019",
     "allowJs": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
     "moduleDetection": "force",
     "isolatedModules": true,
     /* Strictness */
@@ -14,7 +13,7 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     /* Transpiling with other tools */
-    "module": "esnext",
+    "module": "preserve",
     "noEmit": true,
     /* lib */
     "lib": ["es2022"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,21 @@
 {
-  "include": [
-    "src"
-  ],
   "compilerOptions": {
-    "outDir": "build",
-    "target": "ES6",
-    "lib": [
-      "esNext",
-    ],
-    "moduleResolution": "Node",
-    "strict": true,
-    "importHelpers": true,
+    /* Base Options: */
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
-    "experimentalDecorators": true,
-    "exactOptionalPropertyTypes": true,
+    "target": "es2019",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    /* Strictness */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    /* Transpiling with other tools */
+    "module": "preserve",
+    "noEmit": true,
+    /* lib */
+    "lib": ["es2022"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "es2019",
     "allowJs": true,
     "resolveJsonModule": true,
+    "moduleResolution": "node",
     "moduleDetection": "force",
     "isolatedModules": true,
     /* Strictness */
@@ -13,7 +14,7 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     /* Transpiling with other tools */
-    "module": "preserve",
+    "module": "esnext",
     "noEmit": true,
     /* lib */
     "lib": ["es2022"]


### PR DESCRIPTION
[The TSConfig Cheat Sheet](https://www.totaltypescript.com/tsconfig-cheat-sheet)を参考にしtsconfigの更新を行った。
最新のtsconfigを使用するために、typescriptのバージョンを`^5.3.3`から`^5.5.4`に変更した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - TypeScriptのコンパイラオプションが更新され、プロジェクトの互換性と厳密性が向上しました。
  - JavaScriptファイルのコンパイルを許可する`allowJs`オプションが追加されました。
  - JSONファイルをモジュールとしてインポートできる`resolveJsonModule`オプションが追加されました。

- **改善**
  - ターゲットバージョンが`ES6`から`es2019`に変更され、最新のJavaScript機能が利用可能になりました。
  - 型チェックの厳密性が向上し、より安全なコードが実現されます。
  - `lib`オプションが`es2022`に更新され、最新のECMAScript機能が利用可能になりました。
  - イベントが存在しない場合のエラーハンドリングが追加され、より堅牢な機能が実現されました。
  - 無効な`dayOfWeek`プロパティに対するチェックが追加され、メッセージ生成の精度が向上しました。
  - TypeScriptのバージョンが`^5.3.3`から`^5.5.4`に更新され、最新の機能や改善が利用可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->