### PR TITLE
chore: GHAの実行順制御を追加 (#CIT-932)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,9 +1,7 @@
 name: Check
 on:
   pull_request:
-  push:
-    branches:
-      - "main"
+  workflow_call:
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,10 @@ on:
       - "**.md"
   workflow_dispatch:
 jobs:
+  check:
+    uses: ./.github/workflows/check.yml
   deploy:
+    needs: check
     runs-on: ubuntu-latest
     env:
       clasp_config_project: ${{ github.workspace }}/.clasp.prod.json


### PR DESCRIPTION
このレポジトリでは、GHAのワークフローをcheckとdeployで分けている。
しかし、これらのワークフローはどちらが先に実行されるかが保証されていないため、mainブランチにpushした際にdeploy→checkという順番で実行されてしまうことがある。

この問題を解決するために、[workflow_call](https://docs.github.com/ja/actions/sharing-automations/reusing-workflows)を使用し、mainブランチにpushした際に必ずcheck→deployの順に実行されるようにした。

※ 以下の写真は個人レポジトリで実験を行った時のログ（ `check2` は本レポジトリで存在しないことに注意）
<img width="815" alt="スクリーンショット 2024-09-04 17 00 12" src="https://github.com/user-attachments/assets/8ac8ebbe-b837-4c0e-8408-1a895a2ae6a3">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プルリクエストイベントとワークフロー呼び出しイベントに応じて動作する新しいCI/CDワークフローが追加されました。
  - デプロイメント前にコードの検証を行う「チェック」ジョブが追加され、デプロイメントの前に成功が必要となります。

- **改善**
  - ワークフローの実行順序が強化され、より制御された環境でのコード検証が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->