### PR TITLE
chore: PR TitleをLintするGHAとdependabotを導入する (#CIT-940)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "chore(gha)"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "07:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(dev-deps)"
+    groups:
+      dependencies:
+        dependency-type: "production"
+      dev-dependencies:
+        dependency-type: "development"

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,4 +1,4 @@
-name: Lint & Link PR with Notion
+name: Lint pr title
 on:
   pull_request:
     types:
@@ -13,7 +13,7 @@ env:
   TZ: "Asia/Tokyo"
 
 jobs:
-  lint-pr-with-notion:
+  lint-pr-title:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lint-pr-with-notion.yml
+++ b/.github/workflows/lint-pr-with-notion.yml
@@ -13,23 +13,12 @@ env:
   TZ: "Asia/Tokyo"
 
 jobs:
-  lint-and-link-pr-with-notion:
+  lint-pr-with-notion:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Link PR with Notion
-        uses: siiibo/link-pr-with-notion@main
-        with:
-          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
-          NOTION_DATABASE_TASKS_ID: ${{ secrets.NOTION_DATABASE_TASKS_ID }}
-          NOTION_DATABASE_SPRINTS_ID: ${{ secrets.NOTION_DATABASE_SPRINTS_ID }}
-          NOTION_PROJECT_ID: ${{ secrets.NOTION_PROJECT_ID }}
-          NOTION_TASK_ASSIGNEES: ${{ secrets.NOTION_TASK_ASSIGNEES }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Lint PR Title
         id: lint-pr-title
         uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/lint-pr-with-notion.yml
+++ b/.github/workflows/lint-pr-with-notion.yml
@@ -1,0 +1,50 @@
+name: Lint & Link PR with Notion
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+concurrency: # NOTE: 複数のPRでWorkflowが同時に実行されないように設定する必要がある
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+env:
+  TZ: "Asia/Tokyo"
+
+jobs:
+  lint-and-link-pr-with-notion:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Link PR with Notion
+        uses: siiibo/link-pr-with-notion@main
+        with:
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          NOTION_DATABASE_TASKS_ID: ${{ secrets.NOTION_DATABASE_TASKS_ID }}
+          NOTION_DATABASE_SPRINTS_ID: ${{ secrets.NOTION_DATABASE_SPRINTS_ID }}
+          NOTION_PROJECT_ID: ${{ secrets.NOTION_PROJECT_ID }}
+          NOTION_TASK_ASSIGNEES: ${{ secrets.NOTION_TASK_ASSIGNEES }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lint PR Title
+        id: lint-pr-title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            chore
+            ci
+            perf
+            docs
+            style
+            test
+            revert
+          subjectPattern: .+\s\(#\w+-\d+\)\s?$ # check if linked with Notion Task


### PR DESCRIPTION
 lint-and-link-pr-with-notionを行うGHAとdependabotを導入した。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
  - Dependabotを使用して、GitHub Actionsおよびnpmの依存関係を自動的に更新する設定を追加しました。
  - プルリクエストのタイトルを検証し、NotionタスクとリンクするGitHub Actionsワークフローを導入しました。
  - プルリクエストのタイトルに対するリントを行う新しいGitHub Actionsワークフローを追加しました。

- **改善**
  - 依存関係の更新を月ごとに自動化し、コミットメッセージのプレフィックスを設定しました。
  - プルリクエストの管理が向上し、トレーサビリティが強化されました。
  - プルリクエストのタイトルが意味のある形式に保たれるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->