### PR TITLE
fix: 前週に予定がない場合に繰り返し予定を削除できない問題を修正 (#CIT-953)

### DIFF
--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -294,14 +294,7 @@ const deleteRecurringEvents = (
   const calendarId = getConfig().CALENDAR_ID;
   const advancedCalendar = getAdvancedCalendar();
 
-  const events =
-    advancedCalendar.list(calendarId, {
-      timeMin: startOfDay(subWeeks(after, 4)).toISOString(),
-      timeMax: endOfDay(after).toISOString(),
-      singleEvents: true,
-      orderBy: "startTime",
-      q: userEmail,
-    }).items ?? [];
+  const events = getCandidateEventsToDelete(advancedCalendar, calendarId, after, userEmail);
 
   const recurrenceEndEventIdsResult = getRecurrenceEndEventIds(events, dayOfWeeks);
 
@@ -345,6 +338,24 @@ const deleteRecurringEvents = (
     .filter(isNotUndefined);
   return ok(deleteEvents);
 };
+
+function getCandidateEventsToDelete(
+  advancedCalendar: GoogleAppsScript.Calendar.Collection.EventsCollection,
+  calendarId: string,
+  baseDate: Date,
+  userEmail: string,
+) {
+  return (
+    advancedCalendar.list(calendarId, {
+      // NOTE: 1週間だと祝日等が被った際に予定が取得できない場合があるので、余裕を持って4週間分取得している
+      timeMin: startOfDay(subWeeks(baseDate, 4)).toISOString(),
+      timeMax: endOfDay(baseDate).toISOString(),
+      singleEvents: true,
+      orderBy: "startTime",
+      q: userEmail,
+    }).items ?? []
+  );
+}
 
 const getRecurrenceEndEventIds = (
   events: GoogleAppsScript.Calendar.Schema.Event[],

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -352,9 +352,9 @@ const getRecurrenceEndEventId = (
   const targetDayOfWeek = convertDayOfWeekJapaneseToNumber(dayOfWeek);
   //NOTE: 予定の最後から検索するため、逆順にソート
   const sortedEvents = events.sort((a, b) => {
-    const dayOfWeekA = new Date(a.start?.dateTime ?? "").getDay();
-    const dayOfWeekB = new Date(b.start?.dateTime ?? "").getDay();
-    return dayOfWeekB - dayOfWeekA;
+    const dateA = a.start?.dateTime ?? "";
+    const dateB = b.start?.dateTime ?? "";
+    return dateA.localeCompare(dateB);
   });
   const event = sortedEvents.find((event) => {
     const eventDayOfWeek = event.start?.dateTime ? new Date(event.start.dateTime).getDay() : undefined;

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -305,11 +305,11 @@ const deleteRecurringEvents = (
 
   const recurrenceEndEventIds = getRecurrenceEndEventIds(events, dayOfWeeks);
 
-  if (recurrenceEndEventIds === undefined) {
-    return err("削除対象の予定が見つかりませんでした");
+  if (recurrenceEndEventIds.isErr()) {
+    return err(recurrenceEndEventIds.error);
   }
 
-  const detailedEvents = recurrenceEndEventIds.map((recurringEventId) => {
+  const detailedEvents = recurrenceEndEventIds.value.map((recurringEventId) => {
     const eventDetail = advancedCalendar.get(calendarId, recurringEventId);
     return { eventDetail, recurringEventId };
   });
@@ -347,7 +347,7 @@ const deleteRecurringEvents = (
 const getRecurrenceEndEventIds = (
   events: GoogleAppsScript.Calendar.Schema.Event[],
   dayOfWeeks: DayOfWeek[],
-): string[] | undefined => {
+): Result<string[], string> => {
   const recurrenceEndEventIds = dayOfWeeks.map((dayOfWeek) => {
     const targetDayOfWeek = convertDayOfWeekJapaneseToNumber(dayOfWeek);
 
@@ -368,10 +368,10 @@ const getRecurrenceEndEventIds = (
     recurrenceEndEventIds.length === 0 ||
     recurrenceEndEventIds.some((recurrenceEndEventId) => recurrenceEndEventId === undefined)
   ) {
-    return undefined;
+    return err("削除対象の予定が見つかりませんでした");
   }
 
-  return recurrenceEndEventIds.filter(isNotUndefined);
+  return ok(recurrenceEndEventIds.filter(isNotUndefined));
 };
 
 const getCalendar = () => {

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -358,7 +358,7 @@ const getRecurrenceEndEventId = (
   });
   const event = sortedEvents.find((event) => {
     const eventDayOfWeek = event.start?.dateTime ? new Date(event.start.dateTime).getDay() : undefined;
-    return eventDayOfWeek !== undefined && targetDayOfWeek === eventDayOfWeek;
+    return eventDayOfWeek !== undefined && targetDayOfWeek === eventDayOfWeek && event.recurringEventId !== undefined;
   });
   return event?.recurringEventId;
 };

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -350,11 +350,12 @@ const getRecurrenceEndEventId = (
   dayOfWeek: DayOfWeek,
 ): string | undefined => {
   const targetDayOfWeek = convertDayOfWeekJapaneseToNumber(dayOfWeek);
+
   //NOTE: 予定の最後から検索するため、逆順にソート
   const sortedEvents = events.sort((a, b) => {
     const dateA = a.start?.dateTime ?? "";
     const dateB = b.start?.dateTime ?? "";
-    return dateA.localeCompare(dateB);
+    return dateB.localeCompare(dateA);
   });
   const event = sortedEvents.find((event) => {
     const eventDayOfWeek = event.start?.dateTime ? new Date(event.start.dateTime).getDay() : undefined;

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -312,10 +312,10 @@ const deleteRecurringEvents = (
     return err("消去するイベントの取得に失敗しました");
   }
 
-  //NOTE: 上のエラーでundefinedが含まれていることが保証されているため、filterでundefinedを除外
-  const detailedEvents = recurrenceEndEventIds.filter(isNotUndefined).map((recurringEventId: string) => {
-    const eventDetail = advancedCalendar.get(calendarId, recurringEventId);
-    return { eventDetail, recurringEventId };
+  // NOTE: 上のエラーでundefinedが含まれていないことが保証されているため、型アサーションを使用
+  const detailedEvents = recurrenceEndEventIds.map((recurringEventId) => {
+    const eventDetail = advancedCalendar.get(calendarId, recurringEventId as string);
+    return { eventDetail, recurringEventId: recurringEventId as string };
   });
 
   const deleteEvents = detailedEvents

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -303,9 +303,8 @@ const deleteRecurringEvents = (
       q: userEmail,
     }).items ?? [];
 
-  const reversedEvents = events.reverse();
   const recurrenceEndEventIds = dayOfWeeks
-    .map((dayOfWeek) => getRecurrenceEndEventId(reversedEvents, dayOfWeek))
+    .map((dayOfWeek) => getRecurrenceEndEventId(events, dayOfWeek))
     .filter(isNotUndefined);
   if (recurrenceEndEventIds.length === 0) {
     return err("消去するイベントの取得に失敗しました");
@@ -351,7 +350,13 @@ const getRecurrenceEndEventId = (
   dayOfWeek: DayOfWeek,
 ): string | undefined => {
   const targetDayOfWeek = convertDayOfWeekJapaneseToNumber(dayOfWeek);
-  const event = events.find((event) => {
+  //NOTE: 予定の最後から検索するため、逆順にソート
+  const sortedEvents = events.sort((a, b) => {
+    const dayOfWeekA = new Date(a.start?.dateTime ?? "").getDay();
+    const dayOfWeekB = new Date(b.start?.dateTime ?? "").getDay();
+    return dayOfWeekB - dayOfWeekA;
+  });
+  const event = sortedEvents.find((event) => {
     const eventDayOfWeek = event.start?.dateTime ? new Date(event.start.dateTime).getDay() : undefined;
     return eventDayOfWeek !== undefined && targetDayOfWeek === eventDayOfWeek;
   });

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -312,7 +312,7 @@ const deleteRecurringEvents = (
   // NOTE: 上のエラーでundefinedが含まれていないことが保証されているため、型アサーションを使用
   const detailedEvents = recurrenceEndEventIds.map((recurringEventId) => {
     const eventDetail = advancedCalendar.get(calendarId, recurringEventId);
-    return { eventDetail, recurringEventId: recurringEventId };
+    return { eventDetail, recurringEventId };
   });
 
   const deleteEvents = detailedEvents

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -309,7 +309,6 @@ const deleteRecurringEvents = (
     return err("削除対象の予定が見つかりませんでした");
   }
 
-  // NOTE: 上のエラーでundefinedが含まれていないことが保証されているため、型アサーションを使用
   const detailedEvents = recurrenceEndEventIds.map((recurringEventId) => {
     const eventDetail = advancedCalendar.get(calendarId, recurringEventId);
     return { eventDetail, recurringEventId };

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -300,7 +300,7 @@ const deleteRecurringEvents = (
       let events: GoogleAppsScript.Calendar.Schema.Event[] = [];
       let recurrenceEndDate = getRecurrenceEndDate(after, dayOfWeek);
       //NOTE: この箇所で4週間前までのイベント検証を行う
-      for (let a = 0; a < 4; a++) {
+      for (let weekOffset = 0; weekOffset < 4; weekOffset++) {
         events =
           advancedCalendar.list(calendarId, {
             timeMin: startOfDay(recurrenceEndDate).toISOString(),

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -297,25 +297,22 @@ const deleteRecurringEvents = (
   const eventItems = dayOfWeeks
     .map((dayOfWeek) => {
       //NOTE: 仕様的にstartTimeの日付に最初の予定が指定されるため、指定された日付の後で一番近い指定曜日の日付に変更する
-      let events: GoogleAppsScript.Calendar.Schema.Event[] = [];
-      let recurrenceEndDate = getRecurrenceEndDate(after, dayOfWeek);
+      const recurrenceEndDate = getRecurrenceEndDate(after, dayOfWeek);
       //NOTE: この箇所で4週間前までのイベント検証を行う
-      for (let weekOffset = 0; weekOffset < 4; weekOffset++) {
-        events =
-          advancedCalendar.list(calendarId, {
-            timeMin: startOfDay(recurrenceEndDate).toISOString(),
-            timeMax: endOfDay(recurrenceEndDate).toISOString(),
-            singleEvents: true,
-            orderBy: "startTime",
-            maxResults: 1,
-            q: userEmail,
-          }).items ?? [];
-        if (events.length > 0) {
-          break;
-        }
-        recurrenceEndDate = subWeeks(recurrenceEndDate, 1);
-      }
-      const recurringEventId = events[0]?.recurringEventId;
+      const events =
+        advancedCalendar.list(calendarId, {
+          timeMin: startOfDay(subWeeks(recurrenceEndDate, 4)).toISOString(),
+          timeMax: endOfDay(recurrenceEndDate).toISOString(),
+          singleEvents: true,
+          orderBy: "startTime",
+          q: userEmail,
+        }).items ?? [];
+      const reversedEvents = events.reverse();
+      const eventInfo = reversedEvents.find((event) => {
+        const eventDayOfWeek = event.start?.dateTime ? new Date(event.start.dateTime).getDay() : undefined;
+        return eventDayOfWeek !== undefined && convertDayOfWeekJapaneseToNumber(dayOfWeek) === eventDayOfWeek;
+      });
+      const recurringEventId = eventInfo?.recurringEventId;
       return recurringEventId ? { recurringEventId, recurrenceEndDate } : undefined;
     })
     .filter(isNotUndefined);

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -303,13 +303,13 @@ const deleteRecurringEvents = (
       q: userEmail,
     }).items ?? [];
 
-  const recurrenceEndEventIds = getRecurrenceEndEventIds(events, dayOfWeeks);
+  const recurrenceEndEventIdsResult = getRecurrenceEndEventIds(events, dayOfWeeks);
 
-  if (recurrenceEndEventIds.isErr()) {
-    return err(recurrenceEndEventIds.error);
+  if (recurrenceEndEventIdsResult.isErr()) {
+    return err(recurrenceEndEventIdsResult.error);
   }
 
-  const detailedEvents = recurrenceEndEventIds.value.map((recurringEventId) => {
+  const detailedEvents = recurrenceEndEventIdsResult.value.map((recurringEventId) => {
     const eventDetail = advancedCalendar.get(calendarId, recurringEventId);
     return { eventDetail, recurringEventId };
   });

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -311,8 +311,8 @@ const deleteRecurringEvents = (
 
   // NOTE: 上のエラーでundefinedが含まれていないことが保証されているため、型アサーションを使用
   const detailedEvents = recurrenceEndEventIds.map((recurringEventId) => {
-    const eventDetail = advancedCalendar.get(calendarId, recurringEventId as string);
-    return { eventDetail, recurringEventId: recurringEventId as string };
+    const eventDetail = advancedCalendar.get(calendarId, recurringEventId);
+    return { eventDetail, recurringEventId: recurringEventId };
   });
 
   const deleteEvents = detailedEvents

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -303,14 +303,17 @@ const deleteRecurringEvents = (
       q: userEmail,
     }).items ?? [];
 
-  const recurrenceEndEventIds = dayOfWeeks
-    .map((dayOfWeek) => getRecurrenceEndEventId(events, dayOfWeek))
-    .filter(isNotUndefined);
-  if (recurrenceEndEventIds.length === 0) {
+  const recurrenceEndEventIds = dayOfWeeks.map((dayOfWeek) => getRecurrenceEndEventId(events, dayOfWeek));
+
+  if (
+    recurrenceEndEventIds.length === 0 ||
+    recurrenceEndEventIds.some((recurrenceEndEventId) => recurrenceEndEventId === undefined)
+  ) {
     return err("消去するイベントの取得に失敗しました");
   }
 
-  const detailedEventItems = recurrenceEndEventIds.map((recurringEventId: string) => {
+  //NOTE: 上のエラーでundefinedが含まれていることが保証されているため、filterでundefinedを除外
+  const detailedEventItems = recurrenceEndEventIds.filter(isNotUndefined).map((recurringEventId: string) => {
     const eventDetail = advancedCalendar.get(calendarId, recurringEventId);
     return { eventDetail, recurringEventId };
   });

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -313,12 +313,12 @@ const deleteRecurringEvents = (
   }
 
   //NOTE: 上のエラーでundefinedが含まれていることが保証されているため、filterでundefinedを除外
-  const detailedEventItems = recurrenceEndEventIds.filter(isNotUndefined).map((recurringEventId: string) => {
+  const detailedEvents = recurrenceEndEventIds.filter(isNotUndefined).map((recurringEventId: string) => {
     const eventDetail = advancedCalendar.get(calendarId, recurringEventId);
     return { eventDetail, recurringEventId };
   });
 
-  const deleteEvents = detailedEventItems
+  const deleteEvents = detailedEvents
     .map(({ eventDetail, recurringEventId }) => {
       if (!(eventDetail.start?.dateTime && eventDetail.end?.dateTime && eventDetail.summary)) {
         return;

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -364,18 +364,20 @@ const getRecurrenceEndEventIds = (
   const recurrenceEndEventIds = dayOfWeeks.map((dayOfWeek) => {
     const targetDayOfWeek = convertDayOfWeekJapaneseToNumber(dayOfWeek);
 
-    //NOTE: 予定の最後から検索するため、逆順にソート
-    const sortedEvents = events.sort((a, b) => {
+    const sortedEventsByDateDescending = events.sort((a, b) => {
       const dateA = a.start?.dateTime ?? "";
       const dateB = b.start?.dateTime ?? "";
       return dateB.localeCompare(dateA);
     });
-    const event = sortedEvents.find((event) => {
+
+    // NOTE: 日付の降順でsortされたeventsから、指定した曜日の最初のrecurringEventIdを取得
+    const event = sortedEventsByDateDescending.find((event) => {
       const eventDayOfWeek = event.start?.dateTime ? new Date(event.start.dateTime).getDay() : undefined;
       return eventDayOfWeek !== undefined && targetDayOfWeek === eventDayOfWeek && event.recurringEventId !== undefined;
     });
     return event?.recurringEventId;
   });
+
   //NOTE: 一つでもundefinedがある場合はerrを返す
   if (
     recurrenceEndEventIds.length === 0 ||

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -365,7 +365,7 @@ const getRecurrenceEndEventIds = (
     });
     return event?.recurringEventId;
   });
-  //NOTE: 一つでもundefinedがある場合はundefinedを返す
+  //NOTE: 一つでもundefinedがある場合はerrを返す
   if (
     recurrenceEndEventIds.length === 0 ||
     recurrenceEndEventIds.some((recurrenceEndEventId) => recurrenceEndEventId === undefined)

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -311,12 +311,14 @@ const deleteRecurringEvents = (
 
   const detailedEvents = recurrenceEndEventIdsResult.value.map((recurringEventId) => {
     const eventDetail = advancedCalendar.get(calendarId, recurringEventId);
+    //TODO: eventDetailの型をzodで定義してパースする
     return { eventDetail, recurringEventId };
   });
 
   const deleteEvents = detailedEvents
     .map(({ eventDetail, recurringEventId }) => {
       if (!(eventDetail.start?.dateTime && eventDetail.end?.dateTime && eventDetail.summary)) {
+        //NOTE: この箇所でundefinedが発生する場合はないはず
         return;
       }
       const untilTimeUTC = getEndOfDayFormattedAsUTCISO(after);


### PR DESCRIPTION
削除対象となる予定の候補を基準日から1週間前として探索していたが、祝日が被った際やたまたま休暇を入れていた場合に予定が見つからず削除できない状態が発生していたので、基準日から4週間前まで予定を探索するようにした。

### 背景
これまでは1週間前までの予定を取得していたが、休日や休暇に伴って1週間前の予定がなかった場合にエラーが発生してしまっていた。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- 繰り返しイベントの削除機能が強化され、指定日から最大4週間前までのイベントを検索できるようになりました。

- **バグ修正**
	- イベント取得ロジックが改善され、より正確な繰り返しイベントの特定が可能になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->