### PR TITLE
fix(gha): デプロイ用のGHAで発生するEOFエラーを解消する (#CIT-970)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,5 +55,7 @@ jobs:
         run: pnpm run buildpush:prod
       - name: Deploy
         run: |
-          FIRST_LINE=$(echo "${{ github.event.head_commit.message }}" | awk 'NR==1{print $0}')
-          pnpm clasp deploy -i ${{ secrets.DEPLOYMENT_ID }} --description "$FIRST_LINE"
+          set -e
+          FIRST_LINE=$(echo "${{ github.event.head_commit.message }}" | awk 'NR==1{print $0}' | tr -d "`" | tr -d '"' )
+          export DEPLOYMENT_ID=${{ secrets.DEPLOYMENT_ID }}
+          pnpm clasp deploy -i "$DEPLOYMENT_ID" --description "$FIRST_LINE"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,5 +57,4 @@ jobs:
         run: |
           set -e
           FIRST_LINE=$(echo "${{ github.event.head_commit.message }}" | awk 'NR==1{print $0}' | tr -d "`" | tr -d '"' )
-          export DEPLOYMENT_ID=${{ secrets.DEPLOYMENT_ID }}
-          pnpm clasp deploy -i "$DEPLOYMENT_ID" --description "$FIRST_LINE"
+          pnpm clasp deploy -i "${{ secrets.DEPLOYMENT_ID }}" --description "$FIRST_LINE"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       clasp_config_project: ${{ github.workspace }}/.clasp.prod.json
+      DEPLOYMENT_ID: ${{ secrets.DEPLOYMENT_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -57,5 +58,4 @@ jobs:
         run: |
           set -e
           FIRST_LINE=$(echo "${{ github.event.head_commit.message }}" | awk 'NR==1{print $0}' | tr -d "`" | tr -d '"' )
-          export DEPLOYMENT_ID=${{ secrets.DEPLOYMENT_ID }}
           pnpm clasp deploy -i "$DEPLOYMENT_ID" --description "$FIRST_LINE"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,4 @@ jobs:
       - name: Build & Push
         run: pnpm run buildpush:prod
       - name: Deploy
-        run: |
-          set -e
-          FIRST_LINE=$(echo "${{ github.event.head_commit.message }}" | awk 'NR==1{print $0}' | tr -d "`" | tr -d '"' )
-          pnpm clasp deploy -i "${{ secrets.DEPLOYMENT_ID }}" --description "$FIRST_LINE"
+        run: pnpm clasp deploy -i "${{ secrets.DEPLOYMENT_ID }}" --description "$(git log -1 --format=%s)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       clasp_config_project: ${{ github.workspace }}/.clasp.prod.json
-      DEPLOYMENT_ID: ${{ secrets.DEPLOYMENT_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -58,4 +57,5 @@ jobs:
         run: |
           set -e
           FIRST_LINE=$(echo "${{ github.event.head_commit.message }}" | awk 'NR==1{print $0}' | tr -d "`" | tr -d '"' )
+          export DEPLOYMENT_ID=${{ secrets.DEPLOYMENT_ID }}
           pnpm clasp deploy -i "$DEPLOYMENT_ID" --description "$FIRST_LINE"


### PR DESCRIPTION
デプロイを行うGHAでEOFエラーが発生してしまっていたので修正。

https://github.com/siiibo/part-timer-shift-manager/actions/runs/11174148638

```
line 757: unexpected EOF while looking for matching ``'
```

- 主な原因としては以下の通り
    - Corp-ITではPRをmergeする際のcommit messageはPR Title + PR Descriptionである
    - Dependabotが作成するPRの説明欄にて\`が閉じられていない箇所があった（通常 markdownの \`\` でInline Codeを表し、これらは対になっている）
    - GHAでは`${{ github.event.head_commit.message }}` 等の変数を展開したshellスクリプトがstepごとに作られる様だが、変数が展開される際に \`の数が合わないので`unexpected EOF while looking for matching`というエラーが発生
    - 無効なシェルスクリプトが作られたので実行前にエラーが出ている状態
- `${{ github.event.head_commit.message }}`の代わりに`git log`を使うようにして解決
    - この処理で達成したいのは「PRタイトルをGASのdeploy descriptionとして埋め込むこと」なので、同等のことができれば良い
    - `${{ github.event.head_commit.message }}` は変数埋め込みなので実行前に展開→EOFエラーとなるが、git logを使う方法では生成されるシェルスクリプト内にPR Descriptionは含まれないのでエラーが発生しなくなる


ref:  https://github.com/siiibo/part-timer-shift-manager/pull/77#discussion_r1828833208 