### PR TITLE
refactor: 新シフト開始日の変数名を after から newShiftStartDate に変更 (#CIT-1016)

### DIFF
--- a/src/RecurringEventSheet.ts
+++ b/src/RecurringEventSheet.ts
@@ -70,7 +70,7 @@ type NoOperationRow = {
 };
 
 type RecurringEventSheetValues = {
-  after: DateAfterNow;
+  newShiftStartDate: DateAfterNow;
   comment: Comment;
   registrationRows: RegisterRecurringEventRow[];
   modificationRows: ModifyRecurringEventRow[];
@@ -132,7 +132,7 @@ export const setValuesRecurringEventSheet = (sheet: GoogleAppsScript.Spreadsheet
 
 export const getRecurringEventSheetValues = (sheet: GoogleAppsScript.Spreadsheet.Sheet): RecurringEventSheetValues => {
   const sheetRows = getRecurringEventSheetRows(sheet);
-  const after = DateAfterNow.parse(sheet.getRange("A5").getValue());
+  const newShiftStartDate = DateAfterNow.parse(sheet.getRange("A5").getValue());
   const comment = Comment.parse(sheet.getRange("A2").getValue());
   const sheetValues = sheetRows.map((row) => {
     if (row.operation === "追加" && row.dayOfWeek && row.startTime && row.endTime) {
@@ -169,7 +169,7 @@ export const getRecurringEventSheetValues = (sheet: GoogleAppsScript.Spreadsheet
   });
 
   return {
-    after: after,
+    newShiftStartDate: newShiftStartDate,
     comment: comment,
     registrationRows: sheetValues.filter(isRegistrationRow),
     modificationRows: sheetValues.filter(isModificationRow),

--- a/src/shift-changer.ts
+++ b/src/shift-changer.ts
@@ -299,7 +299,8 @@ export const callRecurringEvent = () => {
   }
   const spreadsheetUrl = SpreadsheetApp.getActiveSpreadsheet().getUrl();
   const sheet = getSheet("recurringEvent", spreadsheetUrl);
-  const { after, comment, registrationRows, modificationRows, deletionRows } = getRecurringEventSheetValues(sheet);
+  const { newShiftStartDate, comment, registrationRows, modificationRows, deletionRows } =
+    getRecurringEventSheetValues(sheet);
   console.info(
     `recurringRegistration: ${JSON.stringify(registrationRows)},recurringModification: ${JSON.stringify(modificationRows)},recurringDeletion: ${JSON.stringify(deletionRows)}`,
   ); //NOTE: シート内容を確認するためのログ
@@ -347,7 +348,7 @@ export const callRecurringEvent = () => {
     const payload = JSON.stringify({
       ...basePayload,
       operationType: "registerRecurringEvent",
-      recurringInfo: { after, events: registrationInfos },
+      recurringInfo: { newShiftStartDate, events: registrationInfos },
     } satisfies RegisterRecurringEventRequest);
     const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
       method: "post",
@@ -361,7 +362,7 @@ export const callRecurringEvent = () => {
     const payload = JSON.stringify({
       ...basePayload,
       operationType: "modifyRecurringEvent",
-      recurringInfo: { after, events: modificationInfos },
+      recurringInfo: { newShiftStartDate, events: modificationInfos },
     } satisfies ModifyRecurringEventRequest);
     const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
       method: "post",
@@ -381,7 +382,7 @@ export const callRecurringEvent = () => {
     const payload = JSON.stringify({
       ...basePayload,
       operationType: "deleteRecurringEvent",
-      recurringInfo: { after, dayOfWeeks: deleteDayOfWeeks },
+      recurringInfo: { newShiftStartDate, dayOfWeeks: deleteDayOfWeeks },
     } satisfies DeleteRecurringEventRequest);
     const options: GoogleAppsScript.URL_Fetch.URLFetchRequestOptions = {
       method: "post",
@@ -398,7 +399,7 @@ export const callRecurringEvent = () => {
   }
   const recurringEventMessageToNotify = createMessageForRecurringEvent(
     partTimerProfile,
-    after,
+    newShiftStartDate,
     createMessageForRegisterRecurringEvent(registrationInfos),
     modifyEventStrings,
     deleteEventStrings,
@@ -475,14 +476,14 @@ const createMessageForDeleteRecurringEvent = (deleteEvens: Event[], deletionInfo
 
 const createMessageForRecurringEvent = (
   { job, lastName }: PartTimerProfile,
-  after: Date,
+  newShiftStartDate: Date,
   registerEventStrings: string,
   modifyEventStrings: string,
   deleteEventStrings: string,
   comment: string,
 ): string => {
   const message = [
-    `${job}${lastName}さんが${format(after, "yyyy/MM/dd")}以降の固定シフトを変更しました`,
+    `${job}${lastName}さんが${format(newShiftStartDate, "yyyy/MM/dd")}以降の固定シフトを変更しました`,
     registerEventStrings,
     modifyEventStrings,
     deleteEventStrings,


### PR DESCRIPTION
変数名 after が何を表現しているか分かりづらかったため、変数名を変更した。

[新シフト開始日に指定した日に旧シフトが入っている場合に予定が削除されない問題の修正](https://www.notion.so/siiibo/14a35ecbc23480cd978ec3deb9392e2a) に向けて。
（余計な差分を減らすためPRを分けた）