### PR TITLE
fix: 新シフト開始日に指定した日に旧シフトが入っている場合に予定が削除されない問題の修正 (#CIT-1016)

### DIFF
--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -294,7 +294,7 @@ const deleteRecurringEvents = (
   const calendarId = getConfig().CALENDAR_ID;
   const advancedCalendar = getAdvancedCalendar();
 
-  const events = getCandidateEventsToDelete(advancedCalendar, calendarId, newShiftStartDate, userEmail);
+  const events = getCandidateEventsOfOldShiftEnd(advancedCalendar, calendarId, newShiftStartDate, userEmail);
 
   const recurrenceEndEventIdsResult = getRecurrenceEndEventIds(events, dayOfWeeks);
 
@@ -339,7 +339,7 @@ const deleteRecurringEvents = (
   return ok(deleteEvents);
 };
 
-function getCandidateEventsToDelete(
+function getCandidateEventsOfOldShiftEnd(
   advancedCalendar: GoogleAppsScript.Calendar.Collection.EventsCollection,
   calendarId: string,
   newShiftStartDate: Date,

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -1,4 +1,4 @@
-import { addWeeks, endOfDay, format, nextDay, startOfDay, subHours, subWeeks } from "date-fns";
+import { addWeeks, endOfDay, format, nextDay, startOfDay, subDays, subHours, subWeeks } from "date-fns";
 import { type Result, err, ok } from "neverthrow";
 import { z } from "zod";
 
@@ -349,7 +349,8 @@ function getCandidateEventsOfOldShiftEnd(
     advancedCalendar.list(calendarId, {
       // NOTE: 1週間だと祝日等が被った際に予定が取得できない場合があるので、余裕を持って4週間分取得している
       timeMin: startOfDay(subWeeks(newShiftStartDate, 4)).toISOString(),
-      timeMax: endOfDay(newShiftStartDate).toISOString(),
+      // NOTE: 旧シフトの最終日候補を取得するため、timeMaxにはnewShiftStartDateを含めない
+      timeMax: endOfDay(subDays(newShiftStartDate, 1)).toISOString(),
       singleEvents: true,
       orderBy: "startTime",
       q: userEmail,

--- a/src/shift-changer-api.ts
+++ b/src/shift-changer-api.ts
@@ -342,14 +342,14 @@ const deleteRecurringEvents = (
 function getCandidateEventsToDelete(
   advancedCalendar: GoogleAppsScript.Calendar.Collection.EventsCollection,
   calendarId: string,
-  baseDate: Date,
+  newShiftStartDate: Date,
   userEmail: string,
 ) {
   return (
     advancedCalendar.list(calendarId, {
       // NOTE: 1週間だと祝日等が被った際に予定が取得できない場合があるので、余裕を持って4週間分取得している
-      timeMin: startOfDay(subWeeks(baseDate, 4)).toISOString(),
-      timeMax: endOfDay(baseDate).toISOString(),
+      timeMin: startOfDay(subWeeks(newShiftStartDate, 4)).toISOString(),
+      timeMax: endOfDay(newShiftStartDate).toISOString(),
       singleEvents: true,
       orderBy: "startTime",
       q: userEmail,


### PR DESCRIPTION
新シフト開始日に指定した日に旧シフトが入っている場合に予定が削除されないバグがあったので修正。

- 再現手順
    - 2024/12/02（月）を新シフト開始日とし、毎週月曜日のシフトを**作成**
    - 2024/12/16（月）を新シフト開始日とし、毎週月曜日のシフトを**削除**
- 期待される動作
    - 2024/12/16（月）以降の月曜日の予定が削除される
- 実際の動作
    - 2024/12/16（月）のシフトが残ってしまう


旧シフトの最終日候補を取得する処理で新シフト開始日を含めていたことが原因 (ref: https://github.com/siiibo/part-timer-shift-manager/pull/81#discussion_r1857932994)