### PR TITLE
fix: 祝日カレンダーの参照先をGoogle純正のものから内製した銀行休業日カレンダーに変更する (#CIT-1008)

### DIFF
--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -1,27 +1,10 @@
-import { getDate, getMonth, isWeekend, set } from "date-fns";
-
-const isHoliday = (day: Date): boolean => {
-  const calendarId = "ja.japanese#holiday@group.v.calendar.google.com";
-  const calendar = CalendarApp.getCalendarById(calendarId);
-  const holidayEvents = calendar.getEventsForDay(day);
-  return holidayEvents.length > 0;
-};
+import { isWeekend, set } from "date-fns";
 
 export const isBankHoliday = (date: Date): boolean => {
-  // 12/31
-  if (getMonth(date) === 11 && getDate(date) === 31) {
-    return true;
-  }
-  // 1/1 ~ 1/3
-  if (getMonth(date) === 0) {
-    if (getDate(date) === 1 || getDate(date) === 2 || getDate(date) === 3) {
-      return true;
-    }
-  }
-  if (isHoliday(date) || isWeekend(date)) {
-    return true;
-  }
-  return false;
+  const calendarId = "c_0c278abe4ff7753bce9736b216c2d9ea4d022aa56879589f4ff71152fb7eaae8@group.calendar.google.com";
+  const calendar = CalendarApp.getCalendarById(calendarId);
+  const bankHolidayEvents = calendar.getEventsForDay(date);
+  return bankHolidayEvents.length > 0 || isWeekend(date);
 };
 
 //NOTE: Googleスプレッドシートでは時間のみの入力がDate型として取得される際、日付部分はデフォルトで1899/12/30となるため適切な日付情報に更新する必要がある


### PR DESCRIPTION
Google Calendar公式が提供している[祝日カレンダー](https://calendar.google.com/calendar/embed?src=ja.japanese%23holiday%40group.v.calendar.google.com&ctz=Asia%2FTokyo)の仕様変更かバグ？で、2024年から七五三（2024/11/15）やクリスマス（2024/12/25）など国民の祝日以外の日が表示されるようになってしまった。

休業日判定の利用用途には不向きなため、カレンダーの参照先をGoogle純正のものから内製した銀行休業日カレンダーに変更する。